### PR TITLE
Don't set selection in dispatch() call

### DIFF
--- a/src/inline-edit.ts
+++ b/src/inline-edit.ts
@@ -558,7 +558,6 @@ class InputWidget extends WidgetType {
             }),
             setLoading.of(false),
           ],
-          selection: EditorSelection.cursor(state.to),
         });
       } catch (error) {
         if (error instanceof DOMException && error.name === "AbortError") {


### PR DESCRIPTION
- Fixes #6 

Per the [CodeMirror reference](https://codemirror.net/docs/ref/#state.TransactionSpec.selection):

> When set, this transaction explicitly updates the selection. Offsets in this selection should refer to the document as it is after the transaction.

So if you

- Have a 100-char long document
- Select all of it
- Get an AI suggestion that shortens it to 50 chars
- But say that the cursor should be at the selection end, which is char 100

This'll produce the error reported. It'll happen in other situations where the selection end point no longer exists in the document.

This just removes the manual selection control because the default behavior - setting it to the start of the selected text - seems totally passable to me.