### PR TITLE
Make close text a clickable button that closes the UI

### DIFF
--- a/src/inline-edit.ts
+++ b/src/inline-edit.ts
@@ -603,11 +603,7 @@ class InputWidget extends WidgetType {
         e.preventDefault();
         await handleSubmit();
       } else if (e.key === "Escape") {
-        this.cleanup();
-        view.dispatch({
-          effects: [showInput.of({ show: false, from: 0, to: 0 }), setLoading.of(false)],
-        });
-        view.focus();
+        onCancel();
       }
     });
 

--- a/src/inline-edit.ts
+++ b/src/inline-edit.ts
@@ -481,25 +481,26 @@ class InputWidget extends WidgetType {
     loadingIndicator.setAttribute("aria-live", "polite");
     loadingIndicator.textContent = "Generating";
 
-    const cancelButton = document.createElement("button");
-    cancelButton.className = "cm-ai-cancel-btn";
-    cancelButton.textContent = "Cancel";
-    cancelButton.setAttribute("aria-label", "Cancel code generation");
-    cancelButton.addEventListener("click", () => {
+    const onCancel = () => {
       this.cleanup();
       view.dispatch({
         effects: [showInput.of({ show: false, from: 0, to: 0 }), setLoading.of(false)],
       });
       view.focus();
-    });
+    };
+
+    const cancelButton = document.createElement("button");
+    cancelButton.className = "cm-ai-cancel-btn";
+    cancelButton.textContent = "Cancel";
+    cancelButton.setAttribute("aria-label", "Cancel code generation");
+    cancelButton.addEventListener("click", onCancel);
 
     loadingContainer.append(cancelButton, loadingIndicator);
 
-    const helpInfo = document.createElement("div");
+    const helpInfo = document.createElement("button");
     helpInfo.className = "cm-ai-help-info";
-    helpInfo.setAttribute("role", "status");
-    helpInfo.setAttribute("aria-live", "polite");
     helpInfo.textContent = "Esc to close";
+    helpInfo.addEventListener("click", onCancel);
 
     const isLoading = view.state.field(loadingState);
     if (isLoading) {

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -51,9 +51,14 @@ export const aiTheme = EditorView.baseTheme({
     paddingLeft: "10px",
     height: "18px",
     color: "light-dark(rgb(109, 117, 125), rgb(170, 170, 170))",
+    display: "block",
+    marginRight: "auto",
     // "@media (prefers-color-scheme: dark)": {
     // 	color: "rgb(170, 170, 170)",
     // },
+  },
+  ".cm-ai-help-info:hover": {
+    color: "light-dark(rgb(89, 97, 105), rgb(190, 190, 190))",
   },
   ".cm-ai-generate-btn": {
     background: "#0E639C",


### PR DESCRIPTION
- Fixes #8

Noticed that this previously had an aria-role. I decided to remove it because, as a button, it'll have a default `button` role which should probably be maintained - tradeoffs there, fine with another solution if you prefer something else!