### PR TITLE
Set a maximum width for the input UI by default

### DIFF
--- a/src/theme.ts
+++ b/src/theme.ts
@@ -30,7 +30,7 @@ export const aiTheme = EditorView.baseTheme({
     display: "flex",
     flexDirection: "column",
     gap: "4px",
-    width: "calc(100% + 7px)",
+    width: "min(calc(100% + 7px), 500px)",
     padding: "5px 5px",
     margin: "0 -6px",
     backgroundColor: "light-dark(rgb(241, 243, 245), rgb(40, 40, 40))",


### PR DESCRIPTION
- Fixes #12

Nothing whiz-bang, just a CSS-implemented max width. I don't see a way currently to get items within `cm-scrollable` to only occupy the width of the codemirror wrapper element.