### PR TITLE
Clear input field when a suggestion is accepted

### DIFF
--- a/src/state.ts
+++ b/src/state.ts
@@ -94,15 +94,16 @@ export const inputValueState = StateField.define<InputValueState>({
     return { shouldFocus: false, inputValue: "" };
   },
   update(value, tr) {
+    let updated = value;
     for (const e of tr.effects) {
       if (e.is(setInputValue)) {
-        return { shouldFocus: value.shouldFocus, inputValue: e.value };
+        updated = { ...updated, inputValue: e.value };
       }
       if (e.is(setInputFocus)) {
-        return { shouldFocus: e.value, inputValue: value.inputValue };
+        updated = { ...updated, shouldFocus: e.value };
       }
     }
-    return value;
+    return updated;
   },
 });
 


### PR DESCRIPTION
- Fixes #21

The crux was the `update()` method in `inputValueState`, which could only handle a `setInputValue` or `setInputFocus` effect but not both at once. The rest of this is mostly organization.