### PR TITLE
Prevent clicks on generate from propagating to the cancel button

### DIFF
--- a/src/inline-edit.ts
+++ b/src/inline-edit.ts
@@ -587,7 +587,11 @@ class InputWidget extends WidgetType {
       });
     }
 
-    const handleSubmit = async () => {
+    const handleSubmit = async (e?: Event) => {
+      // Prevent a click event on the submit button
+      // passing-through to the cancel button when we unhide
+      // the helpInfo div.
+      e?.stopPropagation();
       const state = view.state.field(inputState);
       const prompt = input.value.trim();
 


### PR DESCRIPTION
Right now there's a behavior in which clicking Generate just hides the UI instead of runs the prompt:

https://github.com/user-attachments/assets/da6f6aab-d717-4619-92c4-169fe93730e8

This is because when the `Generate` button is clicked, we instantly hide that button and show the `Loading…` UI which has the cancel button, and the Cancel button ends up being in the same spot as the Generate button, so the same click event _also_ triggers the Cancel button.

This PR stops propagation of the click event to make sure that it doesn't accidentally click unintended cancel buttons.
