### PR TITLE
Export more components so that consumers can mix & match

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -5,13 +5,27 @@ describe("index.ts exports", () => {
   it("should not change unexpectedly", () => {
     const sortedExports = Object.keys(exports).sort();
     expect(sortedExports).toMatchInlineSnapshot(`
-			[
-			  "acceptAiEdit",
-			  "aiExtension",
-			  "closeAiEditInput",
-			  "rejectAiEdit",
-			  "showAiEditInput",
-			]
-		`);
+      [
+        "acceptAiEdit",
+        "aiExtension",
+        "aiTheme",
+        "closeAiEditInput",
+        "completionState",
+        "defaultKeymaps",
+        "inputState",
+        "inputValueState",
+        "loadingState",
+        "optionsFacet",
+        "rejectAiEdit",
+        "setInputFocus",
+        "setInputValue",
+        "setLoading",
+        "showAiEditInput",
+        "showCompletion",
+        "showInput",
+        "showTooltip",
+        "tooltipState",
+      ]
+    `);
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,3 @@
-export {
-  aiExtension,
-  showAiEditInput,
-  closeAiEditInput,
-  rejectAiEdit,
-  acceptAiEdit,
-} from "./inline-edit.js";
+export * from "./inline-edit.js";
+export * from "./state.js";
+export * from "./theme.js";

--- a/src/inline-edit.ts
+++ b/src/inline-edit.ts
@@ -243,7 +243,7 @@ export function aiExtension(opts: AiExtensionOptions): Extension[] {
   ];
 }
 
-// View plugin to handle selection changes
+/** View plugin to handle selection changes */
 const selectionPlugin = ViewPlugin.fromClass(
   class {
     decorations: DecorationSet;
@@ -346,7 +346,7 @@ const selectionPlugin = ViewPlugin.fromClass(
   },
 );
 
-// Command to show the input prompt
+/** Command to show the input prompt */
 export const showAiEditInput: Command = (view: EditorView) => {
   const { state } = view;
   const selection = state.selection.main;
@@ -389,7 +389,7 @@ export const showAiEditInput: Command = (view: EditorView) => {
   return true;
 };
 
-// Command to close the input prompt
+/** Command to close the input prompt */
 export const closeAiEditInput: Command = (view: EditorView) => {
   view.dispatch({
     effects: [
@@ -402,7 +402,7 @@ export const closeAiEditInput: Command = (view: EditorView) => {
   return true;
 };
 
-// Command to accept the completion
+/** Command to accept the completion */
 export const acceptAiEdit: Command = (view: EditorView) => {
   const completionStateValue = view.state.field(completionState);
   if (completionStateValue) {
@@ -420,7 +420,7 @@ export const acceptAiEdit: Command = (view: EditorView) => {
   return false;
 };
 
-// Command to reject the completion
+/** Command to reject the completion */
 export const rejectAiEdit: Command = (view: EditorView) => {
   const completionStateValue = view.state.field(completionState);
   if (completionStateValue) {

--- a/src/state.ts
+++ b/src/state.ts
@@ -14,14 +14,18 @@ export interface AiOptions {
   };
 }
 
-// Default keymap values
+/**
+ * Default keymap values
+ */
 export const defaultKeymaps = {
   showInput: "Mod-l",
   acceptEdit: "Mod-y",
   rejectEdit: "Mod-u",
 };
 
-// Facet for options
+/**
+ * Facet for options
+ */
 export const optionsFacet = Facet.define<AiOptions, AiOptions>({
   combine: (values) => Object.assign({}, ...values),
 });
@@ -44,10 +48,14 @@ export interface CompletionState {
   newCode: string;
 }
 
-// State effect to show/hide the tooltip
+/**
+ * State effect to show/hide the tooltip
+ */
 export const showTooltip = StateEffect.define<boolean>();
 
-// State field to manage the tooltip visibility
+/**
+ * State field to manage the tooltip visibility
+ */
 export const tooltipState = StateField.define<boolean>({
   create() {
     return false;
@@ -65,10 +73,14 @@ export const tooltipState = StateField.define<boolean>({
   },
 });
 
-// State effect to show/hide the input
+/**
+ * State effect to show/hide the input
+ */
 export const showInput = StateEffect.define<InputState>();
 
-// State field to manage the input visibility and position
+/**
+ * State field to manage the input visibility and position
+ */
 export const inputState = StateField.define<InputState>({
   create() {
     return { show: false, lineFrom: 0, lineTo: 0 };
@@ -83,12 +95,18 @@ export const inputState = StateField.define<InputState>({
   },
 });
 
-// State effect to set the input value
+/**
+ * State effect to set the input value
+ */
 export const setInputValue = StateEffect.define<string>();
-// State effect to set the input focus
+/**
+ * State effect to set the input focus
+ */
 export const setInputFocus = StateEffect.define<boolean>();
 
-// State field for the input focus and value
+/**
+ * State field for the input focus and value
+ */
 export const inputValueState = StateField.define<InputValueState>({
   create() {
     return { shouldFocus: false, inputValue: "" };
@@ -107,10 +125,14 @@ export const inputValueState = StateField.define<InputValueState>({
   },
 });
 
-// State effect to show/hide the completion
+/**
+ * State effect to show/hide the completion
+ */
 export const showCompletion = StateEffect.define<CompletionState | null>();
 
-// State field to manage the completion
+/**
+ * State field to manage the completion
+ */
 export const completionState = StateField.define<CompletionState | null>({
   create() {
     return null;
@@ -125,9 +147,15 @@ export const completionState = StateField.define<CompletionState | null>({
   },
 });
 
-// State effect and field for loading status
+/**
+ * State effect and field for loading status
+ */
 export const setLoading = StateEffect.define<boolean>();
 
+/**
+ * State effect that manages whether the displayed UI
+ * shows a loading indicator or not.
+ */
 export const loadingState = StateField.define<boolean>({
   create() {
     return false;


### PR DESCRIPTION
- Fixes #26

This just exports more (and updates the test that asserts the exported surface) as well as changes some C++ style comments into JSDoc comments, so the additional API surface has inline editor help.