### PR TITLE
Use combineConfig for configuration, expose listeners

### DIFF
--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -12,9 +12,13 @@ describe("index.ts exports", () => {
         "closeAiEditInput",
         "completionState",
         "defaultKeymaps",
+        "inputPromptDecoration",
         "inputState",
         "inputValueState",
+        "lineShiftListener",
         "loadingState",
+        "newCodeDecoration",
+        "oldCodeDecoration",
         "optionsFacet",
         "rejectAiEdit",
         "setInputFocus",
@@ -25,6 +29,7 @@ describe("index.ts exports", () => {
         "showInput",
         "showTooltip",
         "tooltipState",
+        "tooltipVisibilityListener",
       ]
     `);
   });


### PR DESCRIPTION
This exposes more of the extensions that are wrapped by `aiExtension()` to make them usable ala carte. Also uses `combineConfig` to make `optionsFacet` receive default values, and consolidates down to one options configuration interface.