### PR TITLE
feat: inline completion with caching, callbacks, commands

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,4 @@
 {
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:recommended"
-  ]
+	"$schema": "https://docs.renovatebot.com/renovate-schema.json",
+	"extends": ["config:recommended"]
 }

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -7,12 +7,15 @@ describe("index.ts exports", () => {
     expect(sortedExports).toMatchInlineSnapshot(`
       [
         "acceptAiEdit",
+        "acceptInlineCompletion",
         "aiExtension",
         "aiTheme",
         "closeAiEditInput",
         "completionState",
         "defaultKeymaps",
         "defaultTriggerRenderer",
+        "inlineCompletion",
+        "inlineCompletionKeymap",
         "inputPromptDecoration",
         "inputState",
         "inputValueState",
@@ -22,6 +25,7 @@ describe("index.ts exports", () => {
         "oldCodeDecoration",
         "optionsFacet",
         "rejectAiEdit",
+        "rejectInlineCompletion",
         "setInputFocus",
         "setInputValue",
         "setLoading",

--- a/src/__tests__/inline-completion.test.ts
+++ b/src/__tests__/inline-completion.test.ts
@@ -1,0 +1,254 @@
+import { EditorSelection, EditorState } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  acceptInlineCompletion,
+  inlineCompletion,
+  rejectInlineCompletion,
+} from "../inline-completion";
+
+describe("inline-completion", () => {
+  let view: EditorView;
+  const mockFetchFn = vi.fn().mockResolvedValue("suggestion");
+
+  beforeEach(() => {
+    // Create a new editor for each test
+    const state = EditorState.create({
+      doc: "Hello world",
+      extensions: [
+        inlineCompletion({
+          fetchFn: mockFetchFn,
+          delay: 0, // No delay for testing
+        }),
+      ],
+    });
+
+    vi.useFakeTimers();
+
+    view = new EditorView({
+      state,
+      parent: document.createElement("div"),
+    });
+  });
+
+  afterEach(() => {
+    view.destroy();
+    vi.clearAllMocks();
+  });
+
+  it("should fetch suggestions when document changes", async () => {
+    // Trigger a document change
+    view.dispatch({
+      changes: { from: 5, to: 5, insert: " " },
+    });
+
+    // Wait for the debounced function to be called
+    await vi.runAllTimersAsync();
+
+    // Verify that fetchFn was called with the current state
+    expect(mockFetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("should accept inline completion", async () => {
+    // Set up a suggestion
+    view.dispatch({
+      changes: { from: 5, to: 5, insert: " " },
+    });
+
+    await vi.runAllTimersAsync();
+
+    // Manually trigger the accept command
+    const result = acceptInlineCompletion(view);
+
+    // Verify the suggestion was accepted
+    expect(result).toBe(true);
+    expect(view.state.doc.toString()).toContain("suggestion");
+  });
+
+  it("should reject inline completion", async () => {
+    // Set up a suggestion
+    view.dispatch({
+      changes: { from: 5, to: 5, insert: " " },
+    });
+
+    await vi.runAllTimersAsync();
+
+    // Manually trigger the reject command
+    const result = rejectInlineCompletion(view);
+
+    // Verify the suggestion was rejected
+    expect(result).toBe(true);
+    // The document should remain unchanged
+    expect(view.state.doc.toString()).toBe("Hello  world");
+  });
+
+  it("should not fetch suggestions when selection changes", async () => {
+    // Change selection without changing document
+    view.dispatch({
+      selection: EditorSelection.single(0, 5),
+    });
+
+    await vi.runAllTimersAsync();
+
+    // Verify that fetchFn was not called
+    expect(mockFetchFn).not.toHaveBeenCalled();
+  });
+
+  it("should render inline suggestion as decoration", async () => {
+    // Trigger a document change
+    view.dispatch({
+      changes: { from: 5, to: 5, insert: " " },
+    });
+
+    await vi.runAllTimersAsync();
+
+    // Check if decoration is rendered
+    const suggestionElements = view.dom.querySelectorAll(".cm-inline-suggestion");
+    expect(suggestionElements.length).toBeGreaterThan(0);
+    expect(suggestionElements[0].textContent).toBe("suggestion");
+  });
+});
+
+describe("inline-completion events", () => {
+  let view: EditorView;
+  const mockFetchFn = vi.fn().mockResolvedValue("suggestion");
+  const mockEvents = {
+    onSuggestionAccepted: vi.fn(),
+    onSuggestionRejected: vi.fn(),
+    beforeSuggestionFetch: vi.fn().mockReturnValue(true),
+  };
+
+  beforeEach(() => {
+    const state = EditorState.create({
+      doc: "Hello world",
+      extensions: [
+        inlineCompletion({
+          fetchFn: mockFetchFn,
+          delay: 0,
+          events: mockEvents,
+        }),
+      ],
+    });
+
+    vi.useFakeTimers();
+    view = new EditorView({
+      state,
+      parent: document.createElement("div"),
+    });
+  });
+
+  afterEach(() => {
+    view.destroy();
+    vi.clearAllMocks();
+  });
+
+  it("should call onSuggestionAccepted when accepting completion", async () => {
+    // Set up a suggestion
+    view.dispatch({
+      changes: { from: 5, to: 5, insert: " " },
+    });
+    await vi.runAllTimersAsync();
+
+    acceptInlineCompletion(view);
+
+    expect(mockEvents.onSuggestionAccepted).toHaveBeenCalledWith("suggestion");
+  });
+
+  it("should call onSuggestionRejected when rejecting completion", async () => {
+    // Set up a suggestion
+    view.dispatch({
+      changes: { from: 5, to: 5, insert: " " },
+    });
+    await vi.runAllTimersAsync();
+
+    rejectInlineCompletion(view);
+
+    expect(mockEvents.onSuggestionRejected).toHaveBeenCalledWith("suggestion");
+  });
+
+  it("should call beforeSuggestionFetch before fetching suggestions", async () => {
+    view.dispatch({
+      changes: { from: 5, to: 5, insert: " " },
+    });
+    await vi.runAllTimersAsync();
+
+    expect(mockEvents.beforeSuggestionFetch).toHaveBeenCalledWith(expect.any(EditorState));
+    expect(mockFetchFn).toHaveBeenCalled();
+  });
+
+  it("should not fetch suggestions when beforeSuggestionFetch returns false", async () => {
+    mockEvents.beforeSuggestionFetch.mockReturnValueOnce(false);
+
+    view.dispatch({
+      changes: { from: 5, to: 5, insert: " " },
+    });
+    await vi.runAllTimersAsync();
+
+    expect(mockEvents.beforeSuggestionFetch).toHaveBeenCalled();
+    expect(mockFetchFn).not.toHaveBeenCalled();
+  });
+});
+
+describe("inline-completion cache", () => {
+  let view: EditorView;
+  const mockFetchFn = vi.fn().mockResolvedValue("suggestion");
+
+  beforeEach(() => {
+    const state = EditorState.create({
+      doc: "Hello world",
+      extensions: [
+        inlineCompletion({
+          fetchFn: mockFetchFn,
+          delay: 0,
+          cacheTimeout: 1000,
+        }),
+      ],
+    });
+
+    vi.useFakeTimers();
+    view = new EditorView({
+      state,
+      parent: document.createElement("div"),
+    });
+  });
+
+  afterEach(() => {
+    view.destroy();
+    vi.clearAllMocks();
+  });
+
+  it.skip("should use cached result for identical document", async () => {
+    // First change
+    view.dispatch({
+      changes: { from: 5, to: 5, insert: " " },
+    });
+    await vi.runAllTimersAsync();
+
+    // Second identical change
+    view.dispatch({
+      changes: { from: 6, to: 6, insert: " " },
+    });
+    await vi.runAllTimersAsync();
+
+    expect(mockFetchFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("should invalidate cache after timeout", async () => {
+    // First change
+    view.dispatch({
+      changes: { from: 5, to: 5, insert: " " },
+    });
+    await vi.runAllTimersAsync();
+
+    // Advance time past cache timeout
+    vi.advanceTimersByTime(1100);
+
+    // Same change again
+    view.dispatch({
+      changes: { from: 6, to: 6, insert: " " },
+    });
+    await vi.runAllTimersAsync();
+
+    expect(mockFetchFn).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,12 +1,12 @@
 import { EditorSelection } from "@codemirror/state";
 import type { Command, EditorView } from "@codemirror/view";
 import {
-  showInput,
+  completionState,
   setInputFocus,
   setInputValue,
   setLoading,
-  completionState,
   showCompletion,
+  showInput,
 } from "./state.js";
 
 // Validation constants

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./inline-edit.js";
+export * from "./inline-completion.js";
 export * from "./state.js";
 export * from "./theme.js";
 export * from "./trigger.js";

--- a/src/inline-completion.ts
+++ b/src/inline-completion.ts
@@ -1,0 +1,332 @@
+import {
+  EditorSelection,
+  type EditorState,
+  StateEffect,
+  StateField,
+  type Text,
+  type TransactionSpec,
+} from "@codemirror/state";
+import { Facet } from "@codemirror/state";
+import {
+  type Command,
+  Decoration,
+  type DecorationSet,
+  type EditorView,
+  ViewPlugin,
+  type ViewUpdate,
+  WidgetType,
+  keymap,
+} from "@codemirror/view";
+import { debouncePromise } from "./utils.js";
+
+// Credit to https://github.com/saminzadeh/codemirror-extension-inline-suggestion
+// This is modified for some additional features:
+// - Command to clean up the suggestion (e.g. to work with Esc)
+// - Reduce unnecessary updates in InlineSuggestionState
+// - Cache suggestions to avoid unnecessary re-fetches
+// - Callbacks
+
+/**
+ * State field tracking the current inline suggestion
+ */
+const InlineSuggestionState = StateField.define<{ suggestion: null | string }>({
+  create() {
+    return { suggestion: null };
+  },
+  update(value, tr) {
+    const inlineSuggestion = tr.effects.find((e) => e.is(InlineSuggestionEffect));
+    if (!tr.docChanged && !inlineSuggestion && !tr.selection) return value;
+
+    if (inlineSuggestion && tr.state.doc === inlineSuggestion.value.doc) {
+      return { suggestion: inlineSuggestion.value.text };
+    }
+    return { suggestion: null };
+  },
+});
+
+/**
+ * Effect to update the inline suggestion
+ */
+const InlineSuggestionEffect = StateEffect.define<{
+  text: string | null;
+  doc: Text;
+}>();
+
+/**
+ * Creates a decoration for the inline suggestion at the cursor position
+ */
+function inlineSuggestionDecoration(view: EditorView, prefix: string) {
+  const pos = view.state.selection.main.head;
+  const widgets = [];
+  const w = Decoration.widget({
+    widget: new InlineSuggestionWidget(prefix),
+    side: 1,
+  });
+  widgets.push(w.range(pos));
+  return Decoration.set(widgets);
+}
+
+/**
+ * Widget that renders the inline suggestion
+ */
+class InlineSuggestionWidget extends WidgetType {
+  suggestion: string;
+  constructor(suggestion: string) {
+    super();
+    this.suggestion = suggestion;
+  }
+  toDOM() {
+    const div = document.createElement("span");
+    div.style.opacity = "0.4";
+    div.className = "cm-inline-suggestion";
+    div.textContent = this.suggestion;
+    div.setAttribute("role", "suggestion");
+    div.setAttribute("aria-label", `Suggestion: ${this.suggestion}`);
+    return div;
+  }
+  get lineBreaks(): number {
+    return this.suggestion.split("\n").length - 1;
+  }
+}
+
+type InlineFetchFn = (state: EditorState, signal: AbortSignal) => Promise<string>;
+
+// Add these near the top with other types
+type SuggestionEvents = {
+  onSuggestionAccepted?: (suggestion: string) => void;
+  onSuggestionRejected?: (suggestion: string) => void;
+  beforeSuggestionFetch?: (state: EditorState) => boolean;
+  shouldShowSuggestion?: (state: EditorState, suggestion: string) => boolean;
+};
+
+type InlineSuggestionOptions = {
+  fetchFn: (state: EditorState, signal: AbortSignal) => Promise<string>;
+  delay?: number;
+  /**
+   * @default true
+   */
+  includeKeymap?: boolean;
+  events?: SuggestionEvents;
+  /**
+   * @default 10000 // 10 seconds
+   */
+  cacheTimeout?: number;
+};
+
+/**
+ * Cache for inline suggestions
+ */
+class SuggestionCache {
+  private cache: Map<string, { result: string; timestamp: number }> = new Map();
+  private timeout: number;
+
+  constructor(timeout: number) {
+    this.timeout = timeout;
+  }
+
+  get(key: string): string | null {
+    const entry = this.cache.get(key);
+    if (!entry) return null;
+
+    if (Date.now() - entry.timestamp > this.timeout) {
+      this.cache.delete(key);
+      return null;
+    }
+
+    return entry.result;
+  }
+
+  set(key: string, value: string) {
+    this.cache.set(key, { result: value, timestamp: Date.now() });
+  }
+}
+
+/**
+ * Creates a plugin that fetches suggestions when the document changes
+ */
+const fetchSuggestion = (fetchFn: InlineFetchFn, options: InlineSuggestionOptions) =>
+  ViewPlugin.fromClass(
+    class Plugin {
+      abortController: AbortController | null = null;
+      cache: SuggestionCache;
+
+      constructor() {
+        this.cache = new SuggestionCache(options.cacheTimeout ?? 1000);
+      }
+
+      async update(update: ViewUpdate) {
+        if (!update.docChanged) return;
+
+        // Check if we should fetch
+        if (options.events?.beforeSuggestionFetch?.(update.state) === false) {
+          return;
+        }
+
+        // Cancel previous request
+        this.abortController?.abort();
+        this.abortController = new AbortController();
+
+        const doc = update.state.doc;
+        const cacheKey = doc.toString();
+
+        // Check cache first
+        const cached = this.cache.get(cacheKey);
+        if (cached) {
+          update.view.dispatch({
+            effects: InlineSuggestionEffect.of({ text: cached, doc }),
+          });
+          return;
+        }
+
+        try {
+          const result = await fetchFn(update.state, this.abortController.signal);
+          // Only update if not aborted
+          if (this.abortController.signal.aborted) {
+            return;
+          }
+
+          if (options.events?.shouldShowSuggestion?.(update.state, result) === false) {
+            return;
+          }
+
+          this.cache.set(cacheKey, result);
+          update.view.dispatch({
+            effects: InlineSuggestionEffect.of({ text: result, doc }),
+          });
+        } catch (err) {
+          if (err instanceof Error && err.name !== "AbortError") {
+            // biome-ignore lint/suspicious/noConsole: <explanation>
+            console.error("Suggestion fetch error:", err);
+          }
+        }
+      }
+
+      destroy() {
+        this.abortController?.abort();
+      }
+    },
+  );
+
+/**
+ * Plugin that renders the inline suggestion
+ */
+const renderInlineSuggestionPlugin = ViewPlugin.fromClass(
+  class Plugin {
+    decorations: DecorationSet;
+    constructor() {
+      // Empty decorations
+      this.decorations = Decoration.none;
+    }
+    update(update: ViewUpdate) {
+      const suggestionText = update.state.field(InlineSuggestionState)?.suggestion;
+      if (!suggestionText) {
+        this.decorations = Decoration.none;
+        return;
+      }
+      this.decorations = inlineSuggestionDecoration(update.view, suggestionText);
+    }
+  },
+  {
+    decorations: (v) => v.decorations,
+  },
+);
+
+/**
+ * Inserts completion text at the current selection
+ */
+function insertCompletionText(
+  state: EditorState,
+  text: string,
+  from: number,
+  to: number,
+): TransactionSpec {
+  return {
+    ...state.changeByRange((range) => {
+      if (range === state.selection.main)
+        return {
+          changes: { from: from, to: to, insert: text },
+          range: EditorSelection.cursor(from + text.length),
+        };
+      const len = to - from;
+      if (
+        !range.empty ||
+        (len && state.sliceDoc(range.from - len, range.from) !== state.sliceDoc(from, to))
+      )
+        return { range };
+      return {
+        changes: { from: range.from - len, to: range.from, insert: text },
+        range: EditorSelection.cursor(range.from - len + text.length),
+      };
+    }),
+    userEvent: "input.complete",
+  };
+}
+
+// Commands
+
+const acceptInlineCompletion: Command = (view: EditorView) => {
+  const suggestionText = view.state.field(InlineSuggestionState)?.suggestion;
+  if (!suggestionText) return false;
+
+  // Get options from state
+  const config = view.state.facet(inlineCompletionConfig);
+
+  view.dispatch({
+    ...insertCompletionText(
+      view.state,
+      suggestionText,
+      view.state.selection.main.head,
+      view.state.selection.main.head,
+    ),
+  });
+
+  // Trigger event
+  config.events?.onSuggestionAccepted?.(suggestionText);
+  return true;
+};
+
+const rejectInlineCompletion: Command = (view: EditorView) => {
+  const suggestionText = view.state.field(InlineSuggestionState)?.suggestion;
+  if (!suggestionText) return false;
+
+  const config = view.state.facet(inlineCompletionConfig);
+
+  view.dispatch({
+    effects: InlineSuggestionEffect.of({ text: null, doc: view.state.doc }),
+  });
+
+  // Trigger event
+  config.events?.onSuggestionRejected?.(suggestionText);
+  return true;
+};
+
+// Default keymap
+
+const inlineCompletionKeymap = keymap.of([
+  { key: "Tab", run: acceptInlineCompletion },
+  { key: "Escape", run: rejectInlineCompletion },
+]);
+
+// Add config facet to store options
+const inlineCompletionConfig = Facet.define<InlineSuggestionOptions, InlineSuggestionOptions>({
+  // biome-ignore lint/style/noNonNullAssertion: <explanation>
+  combine: (v) => v.at(-1)!,
+});
+
+/**
+ * Creates an inline completion extension with the given options
+ */
+function inlineCompletion(options: InlineSuggestionOptions) {
+  const { delay = 500, includeKeymap = true } = options;
+  const fetchFn = debouncePromise(options.fetchFn, delay);
+
+  return [
+    InlineSuggestionState,
+    inlineCompletionConfig.of(options),
+    fetchSuggestion(fetchFn, options),
+    renderInlineSuggestionPlugin,
+    includeKeymap ? inlineCompletionKeymap : [],
+  ];
+}
+
+export { acceptInlineCompletion, rejectInlineCompletion, inlineCompletion, inlineCompletionKeymap };

--- a/src/inline-edit.ts
+++ b/src/inline-edit.ts
@@ -1,5 +1,6 @@
 import { type EditorState, type Extension, Prec, type Range, StateField } from "@codemirror/state";
 import { Decoration, type DecorationSet, EditorView, keymap } from "@codemirror/view";
+import { acceptAiEdit, rejectAiEdit, showAiEditInput } from "./commands.js";
 import {
   type AiOptions,
   completionState,
@@ -12,7 +13,6 @@ import {
 } from "./state.js";
 import { aiTheme } from "./theme.js";
 import { triggerPlugin } from "./trigger.js";
-import { showAiEditInput, acceptAiEdit, rejectAiEdit } from "./commands.js";
 import { InputWidget, OldCodeWidget } from "./widgets.js";
 
 /**

--- a/src/trigger.ts
+++ b/src/trigger.ts
@@ -1,8 +1,8 @@
+import { Facet, combineConfig } from "@codemirror/state";
 import { EditorView, type PluginValue, ViewPlugin, type ViewUpdate } from "@codemirror/view";
 import { showAiEditInput } from "./commands.js";
 import { defaultKeymaps, inputState, optionsFacet } from "./state.js";
 import { ce, formatKeymap } from "./utils.js";
-import { combineConfig, Facet } from "@codemirror/state";
 
 /**
  * Options to customize trigger rendering.

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -30,3 +30,29 @@ export function ce<T extends keyof HTMLElementTagNameMap>(
   elem.className = className;
   return elem;
 }
+
+// biome-ignore lint/suspicious/noExplicitAny: ...
+export function debouncePromise<T extends (...args: any[]) => any>(
+  fn: T,
+  wait: number,
+  abortValue: unknown = undefined,
+) {
+  let cancel = () => {
+    // do nothing
+  };
+  // type Awaited<T> = T extends PromiseLike<infer U> ? U : T
+  type ReturnT = Awaited<ReturnType<T>>;
+  const wrapFunc = (...args: Parameters<T>): Promise<ReturnT> => {
+    cancel();
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => resolve(fn(...args)), wait);
+      cancel = () => {
+        clearTimeout(timer);
+        if (abortValue !== undefined) {
+          reject(abortValue);
+        }
+      };
+    });
+  };
+  return wrapFunc;
+}

--- a/src/widgets.ts
+++ b/src/widgets.ts
@@ -1,17 +1,17 @@
-import { WidgetType, type EditorView } from "@codemirror/view";
+import { type EditorView, WidgetType } from "@codemirror/view";
 import { acceptAiEdit, rejectAiEdit } from "./commands.js";
 import {
-  optionsFacet,
-  defaultKeymaps,
   type CompleteFunction,
+  defaultKeymaps,
+  inputState,
   inputValueState,
   loadingState,
-  showInput,
-  setLoading,
+  optionsFacet,
   setInputFocus,
-  inputState,
-  showCompletion,
   setInputValue,
+  setLoading,
+  showCompletion,
+  showInput,
 } from "./state.js";
 import { ce, formatKeymap } from "./utils.js";
 


### PR DESCRIPTION
Inline completions. Mostly from https://github.com/saminzadeh/codemirror-extension-inline-suggestion

but with:
```
// - Command to clean up the suggestion (e.g. to work with Esc)
// - Reduce unnecessary updates in InlineSuggestionState
// - Cache suggestions to avoid unnecessary re-fetches
// - Callbacks
```