### PR TITLE
Use key-combos from extension options when specified

### DIFF
--- a/src/inline-edit.ts
+++ b/src/inline-edit.ts
@@ -51,6 +51,8 @@ export function aiExtension(options: AiOptions): Extension[] {
     throw new Error("prompt function is required");
   }
 
+  const keymapConfig = {...defaultKeymaps, ...options.keymaps}
+
   return [
     optionsFacet.of(options),
     inputState,
@@ -61,14 +63,14 @@ export function aiExtension(options: AiOptions): Extension[] {
     aiTheme,
     keymap.of([
       {
-        key: defaultKeymaps.showInput,
+        key: keymapConfig.showInput,
         run: showAiEditInput,
       },
     ]),
     Prec.highest([
       keymap.of([
-        { key: defaultKeymaps.acceptEdit, run: acceptAiEdit },
-        { key: defaultKeymaps.rejectEdit, run: rejectAiEdit },
+        { key: keymapConfig.acceptEdit, run: acceptAiEdit },
+        { key: keymapConfig.rejectEdit, run: rejectAiEdit },
       ]),
     ]),
     lineShiftListener,


### PR DESCRIPTION
If keymap overrides are supplied in extension options, they only reflect in UI tooltips. The invocation remains bound to defaults (Cmd-L). The wiring seems to be missing in extension creation?



Misc:

-  I noticed in other places we have:

```js
const keymaps = { ...defaultKeymaps, ...options.keymaps };
```

I'm naming it `keymapConfig` here to avoid confusion with `keymap` usages in the vicinity.

- Mod-L may not be a good default, as some browsers (like Safari) may not allow you to override this combination.
