### PR TITLE
fix edit tooltip position

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -21,7 +21,7 @@ jobs:
       - name: ⎔ Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
-          version: 9
+          version: 10
 
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
       - name: ⎔ Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
-          version: 9
+          version: 10
 
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: ⎔ Setup pnpm
         uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
-          version: 9
+          version: 10
 
       - name: ⎔ Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4

--- a/src/inline-edit/trigger.ts
+++ b/src/inline-edit/trigger.ts
@@ -24,7 +24,11 @@ export function defaultTriggerRenderer(view: EditorView) {
   const trigger = view.state.facet(triggerOptions);
   const dom = ce("div", "cm-ai-tooltip");
   const tooltip = dom.appendChild(ce("div", "cm-ai-tooltip-button"));
-  tooltip.innerHTML = `<span>${trigger.label} <span class="hotkey">${formatKeymap(keymaps.showInput)}</span></span>`;
+  const span = tooltip.appendChild(document.createElement("span"));
+  span.textContent = `${trigger.label} `;
+  const hotkey = span.appendChild(document.createElement("span"));
+  hotkey.className = "hotkey";
+  hotkey.textContent = formatKeymap(keymaps.showInput);
 
   // NOTE: preventing mousedown from propagating here prevents
   // the tooltip from being closed before it can be clicked, but

--- a/src/inline-edit/trigger.ts
+++ b/src/inline-edit/trigger.ts
@@ -137,27 +137,31 @@ export const triggerViewPlugin = ViewPlugin.fromClass(
     #onRead = (view: EditorView) => {
       const range = view.state.selection.ranges.find((range) => !range.empty);
       if (range && !this.suppress) {
-        // Coords here are relative to the scrollable document.
-        const coords = view.coordsAtPos(range.from);
-        if (!coords) return;
+        const fromCoords = view.coordsAtPos(range.from);
+        const toCoords = view.coordsAtPos(range.to);
+        if (!fromCoords || !toCoords) return;
 
         // Check if the selection is visible in the viewport
         const scrollRect = view.dom.getBoundingClientRect();
         const domRect = view.dom.parentElement?.getBoundingClientRect();
 
-        // Check if coords are within the editor's visible area
-        const isInEditorViewport = coords.top >= scrollRect.top &&
-                                  coords.top <= scrollRect.bottom &&
-                                  coords.left >= scrollRect.left &&
-                                  coords.left <= scrollRect.right;
+        // The selection is visible if either end is within the viewport
+        const isEndInEditor = (c: { top: number; left: number }) =>
+          c.top >= scrollRect.top &&
+          c.top <= scrollRect.bottom &&
+          c.left >= scrollRect.left &&
+          c.left <= scrollRect.right;
 
-        // Check if coords are within the parent container's visible area
-        const isInParentViewport = !domRect || (
-          coords.top >= domRect.top &&
-          coords.top <= domRect.bottom &&
-          coords.left >= domRect.left &&
-          coords.left <= domRect.right
-        );
+        const isEndInParent = (c: { top: number; left: number }) =>
+          !domRect || (
+            c.top >= domRect.top &&
+            c.top <= domRect.bottom &&
+            c.left >= domRect.left &&
+            c.left <= domRect.right
+          );
+
+        const isInEditorViewport = isEndInEditor(fromCoords) || isEndInEditor(toCoords);
+        const isInParentViewport = isEndInParent(fromCoords) || isEndInParent(toCoords);
 
         // Hide tooltip if selection is not visible in either viewport
         if (!isInEditorViewport || !isInParentViewport) {
@@ -179,14 +183,17 @@ export const triggerViewPlugin = ViewPlugin.fromClass(
 
         // If the tooltip is slammed to the right side of the page,
         // pull it back so that it isn't quite as slammed.
-        const left = Math.min(coords.left, rightEdge);
+        const left = Math.min(fromCoords.left, rightEdge);
 
-        // If the tooltip is in the overscrolled area at the top,
-        // try to show it just at the top. This relies on the parent
-        // of the codemirror container, which is not an ideal
-        // strategy.
-        let top = coords.top - tooltipRect.height;
-        top = domRect ? Math.max(domRect.y, top) : top;
+        // Place the tooltip above the selection by default. If that
+        // would push it above the parent container (e.g. first line
+        // of a cell), flip it below the entire selection so it doesn't
+        // overlap the selected text.
+        let top = fromCoords.top - tooltipRect.height;
+        const minTop = domRect ? domRect.y : -Infinity;
+        if (top < minTop) {
+          top = toCoords.bottom;
+        }
 
         // Position and show the element
         this.dom.style.left = `${left}px`;

--- a/src/inline-edit/trigger.ts
+++ b/src/inline-edit/trigger.ts
@@ -181,19 +181,21 @@ export const triggerViewPlugin = ViewPlugin.fromClass(
         // do them very often! We may want to cache these in the future.
         const tooltipRect = this.dom.getBoundingClientRect();
 
+        // Prefer anchoring to the selection start; fall back to the
+        // visible end when the start has scrolled out of view.
+        const anchor = isEndInEditor(fromCoords) ? fromCoords : toCoords;
+
         // The furthest right we want to place the tooltip, to avoid
-        // it getting smushed
-        const rightEdge = scrollRect.width - tooltipRect.width;
+        // it getting smushed. Both anchor.left and scrollRect.right
+        // are in viewport coordinates (position: fixed).
+        const rightEdge = scrollRect.right - tooltipRect.width;
+        const left = Math.min(anchor.left, rightEdge);
 
-        // If the tooltip is slammed to the right side of the page,
-        // pull it back so that it isn't quite as slammed.
-        const left = Math.min(fromCoords.left, rightEdge);
-
-        // Place the tooltip above the selection by default. If that
+        // Place the tooltip above the anchor by default. If that
         // would push it above the parent container (e.g. first line
         // of a cell), flip it below the entire selection so it doesn't
         // overlap the selected text.
-        let top = fromCoords.top - tooltipRect.height;
+        let top = anchor.top - tooltipRect.height;
         const minTop = domRect ? domRect.y : -Infinity;
         if (top < minTop) {
           top = toCoords.bottom;

--- a/src/inline-edit/trigger.ts
+++ b/src/inline-edit/trigger.ts
@@ -10,6 +10,8 @@ import { defaultKeymaps, inputState, optionsFacet } from "./state.js";
 interface TriggerOptions {
   render: (view: EditorView) => HTMLElement;
   hideOnBlur: boolean;
+  /** Label text shown on the trigger button. */
+  label: string;
 }
 
 /**
@@ -19,9 +21,10 @@ interface TriggerOptions {
 export function defaultTriggerRenderer(view: EditorView) {
   const options = view.state.facet(optionsFacet);
   const keymaps = { ...defaultKeymaps, ...options.keymaps };
+  const trigger = view.state.facet(triggerOptions);
   const dom = ce("div", "cm-ai-tooltip");
   const tooltip = dom.appendChild(ce("div", "cm-ai-tooltip-button"));
-  tooltip.innerHTML = `<span>Edit <span class="hotkey">${formatKeymap(keymaps.showInput)}</span></span>`;
+  tooltip.innerHTML = `<span>${trigger.label} <span class="hotkey">${formatKeymap(keymaps.showInput)}</span></span>`;
 
   // NOTE: preventing mousedown from propagating here prevents
   // the tooltip from being closed before it can be clicked, but
@@ -46,6 +49,7 @@ export const triggerOptions = Facet.define<Partial<TriggerOptions>, TriggerOptio
     return combineConfig(value, {
       render: defaultTriggerRenderer,
       hideOnBlur: false,
+      label: "Edit with AI",
     });
   },
 });


### PR DESCRIPTION
Fixes https://github.com/marimo-team/marimo/issues/9150

1. Change the tooltip default to "Edit with AI" instead of "Edit". Also makes this tooltip configurable for downstream users.
2. Fix tooltip positioning so that it doesn't overlap with text for both single-line and multi-line.

https://github.com/user-attachments/assets/bc549318-aa5a-4b55-a3f5-210df2298508

Did not add unit tests as we'd just mock a bunch of coordinates, manually tested instead.