### PR TITLE
chore(ci): add --ignore-scripts to release install

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
           cache: pnpm
 
       - name: 📥 Install dependencies
-        run: pnpm install --frozen-lockfile
+        run: pnpm install --ignore-scripts --frozen-lockfile
 
       - name: 🔍 Type Check
         run: pnpm run typecheck


### PR DESCRIPTION
Defense-in-depth against compromised transitive deps executing postinstall/prepare during release. Motivated by the TanStack npm supply-chain compromise (May 2026).

No functional change.