### PR TITLE
chore(ci): split demo.yml into build + deploy jobs

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -7,14 +7,11 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 jobs:
   build:
     name: 🏗️ Build
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
@@ -41,6 +38,17 @@ jobs:
         with:
           path: './demo/dist'
 
+  deploy:
+    name: 🚀 Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
       - name: 🚀 Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
Splits the single build-and-deploy job into the canonical GitHub Pages 2-job pattern: build (no `id-token`) → deploy (only `id-token: write`, runs deploy-pages only).

Resolves the supply-chain audit's OIDC-fused finding on this workflow.