### PR TITLE
ci: adopt deny-all top-level workflow permissions

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -5,8 +5,7 @@ on:
     branches:
       - main
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   build:
@@ -37,6 +36,8 @@ jobs:
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: './demo/dist'
+    permissions:
+      contents: read
 
   deploy:
     name: 🚀 Deploy


### PR DESCRIPTION
Sets each workflow's top-level `permissions:` to `{}` (deny-all) and moves the previously top-level grants into the specific jobs that inherited them. **Effective permissions are unchanged for every job** — this just makes the grants explicit per job so a newly-added job can't silently inherit broad scopes.

Behavior-preserving mechanical change (validated: all touched workflows still parse; per-job effective scopes identical). Workflows whose jobs inherit the org default are left untouched for a manual per-job pass.

_Flagged by github-maintenance Workflow Permissions Audit._