### PR TITLE
ci: enforce lint and report coverage on PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,11 +35,20 @@ jobs:
       - name: 📥 Install dependencies
         run: pnpm install --ignore-scripts --frozen-lockfile
 
+      - name: 🧹 Lint
+        run: pnpm exec biome ci .
+
       - name: 🔍 Type Check
         run: pnpm run typecheck
 
       - name: 🧪 Test
         run: pnpm run test
+
+      - name: 📊 Report Coverage
+        if: always()
+        uses: davelosert/vitest-coverage-report-action@3c50566c523e04813df28de8f7c48dd97d663f1c # v2
+        with:
+          pr-number: auto
 
   security:
     runs-on: ubuntu-latest

--- a/demo/index.ts
+++ b/demo/index.ts
@@ -2,6 +2,7 @@ import { python } from "@codemirror/lang-python";
 import { Prec, type Range } from "@codemirror/state";
 import { Decoration, type DecorationSet, keymap, tooltips, ViewPlugin } from "@codemirror/view";
 import { basicSetup, EditorView } from "codemirror";
+import { triggerOptions } from "../src/index.js";
 import { aiExtension } from "../src/inline-edit/inline-edit.js";
 import { PredictionBackend } from "../src/next-edit-prediction/backend.js";
 import {
@@ -16,7 +17,6 @@ import { nextEditPrediction } from "../src/next-edit-prediction/extension.js";
 import { CURSOR_MARKER } from "../src/next-edit-prediction/types.js";
 import { insertDiffText } from "../src/next-edit-prediction/utils.js";
 import { promptHistory, storePrompt } from "../src/prompt-history/extension.js";
-import { triggerOptions } from "../src/index.js";
 
 const logger = console;
 

--- a/src/inline-edit/__tests__/inline-completion.test.ts
+++ b/src/inline-edit/__tests__/inline-completion.test.ts
@@ -47,7 +47,11 @@ describe("inline-completion", () => {
 
     // Verify that fetchFn was called with the current state
     expect(mockFetchFn).toHaveBeenCalledTimes(1);
-    expect(mockFetchFn).toHaveBeenCalledWith(expect.any(EditorState), expect.any(AbortSignal), expect.any(EditorView));
+    expect(mockFetchFn).toHaveBeenCalledWith(
+      expect.any(EditorState),
+      expect.any(AbortSignal),
+      expect.any(EditorView),
+    );
   });
 
   it("should accept inline completion", async () => {

--- a/src/inline-edit/trigger.ts
+++ b/src/inline-edit/trigger.ts
@@ -126,7 +126,7 @@ export const triggerViewPlugin = ViewPlugin.fromClass(
       // Hide tooltip if hideOnBlur is enabled and editor doesn't have focus
       if (options.hideOnBlur && !view.hasFocus) {
         this.dom.style.display = "none";
-        this.dom.setAttribute('aria-hidden', "true");
+        this.dom.setAttribute("aria-hidden", "true");
         return;
       }
       view.requestMeasure({
@@ -157,12 +157,11 @@ export const triggerViewPlugin = ViewPlugin.fromClass(
           c.left <= scrollRect.right;
 
         const isEndInParent = (c: { top: number; left: number }) =>
-          !domRect || (
-            c.top >= domRect.top &&
+          !domRect ||
+          (c.top >= domRect.top &&
             c.top <= domRect.bottom &&
             c.left >= domRect.left &&
-            c.left <= domRect.right
-          );
+            c.left <= domRect.right);
 
         const isInEditorViewport = isEndInEditor(fromCoords) || isEndInEditor(toCoords);
         const isInParentViewport = isEndInParent(fromCoords) || isEndInParent(toCoords);
@@ -170,12 +169,12 @@ export const triggerViewPlugin = ViewPlugin.fromClass(
         // Hide tooltip if selection is not visible in either viewport
         if (!isInEditorViewport || !isInParentViewport) {
           this.dom.style.display = "none";
-          this.dom.setAttribute('aria-hidden', "true");
+          this.dom.setAttribute("aria-hidden", "true");
           return;
         }
 
         this.dom.style.display = "flex";
-        this.dom.setAttribute('aria-hidden', "false");
+        this.dom.setAttribute("aria-hidden", "false");
 
         // These measurements are definitely slow and we don't want to
         // do them very often! We may want to cache these in the future.
@@ -206,12 +205,12 @@ export const triggerViewPlugin = ViewPlugin.fromClass(
         this.dom.style.top = `${top}px`;
         requestAnimationFrame(() => {
           if (this.dom) {
-            this.dom.setAttribute('aria-hidden', "false");
+            this.dom.setAttribute("aria-hidden", "false");
           }
         });
       } else {
         this.dom.style.display = "none";
-        this.dom.setAttribute('aria-hidden', "true");
+        this.dom.setAttribute("aria-hidden", "true");
       }
     };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,6 +4,13 @@ export default defineConfig({
   root: process.env.VITEST ? "." : "demo",
   test: {
     environment: "jsdom",
+    coverage: {
+      enabled: true,
+      include: ["src/**"],
+      exclude: ["demo/**", "scripts/**"],
+      reportOnFailure: true,
+      reporter: ["text", "html", "json-summary", "json"],
+    },
     watch: false,
   },
   base: "/codemirror-ai/",


### PR DESCRIPTION
## What changed

- **Lint in CI**: added a non-mutating `pnpm exec biome ci .` step to the `test` job (the existing `lint` script is `biome check --write`, which mutates files and is unsafe for CI).
- **Coverage config**: added a `coverage` block to `vite.config.ts` mirroring codemirror-mcp — `enabled: true`, `reportOnFailure: true`, `reporter: ["text", "html", "json-summary", "json"]`, scoped to `src/**`.
- **Coverage reporting**: added the SHA-pinned `davelosert/vitest-coverage-report-action@…3c50566 # v2` step (`if: always()`, `pr-number: auto`) with the same `pull-requests: write` permission codemirror-mcp uses (already present on this job).
- **Mechanical lint fixes**: `biome ci .` initially failed with 3 errors (import ordering + formatting). Ran the repo's fixer (`biome check --write`) once; it reformatted `demo/index.ts`, `src/inline-edit/trigger.ts`, and `src/inline-edit/__tests__/inline-completion.test.ts` (import sort, quote style, line wrapping — no behavior change). Included here so CI passes.

`@vitest/coverage-v8` was already a dev dependency at `3.2.4` (matching `vitest` 3.2.4), so no dependency/lockfile change was needed.

## Why

The lint script and config already existed but CI never ran lint, and no coverage was measured at all. This makes both gates visible on every PR.

## How verified

- `pnpm install --frozen-lockfile`
- `pnpm exec biome ci .` — exit 0 after the mechanical fixes
- `pnpm run test` — passes; `coverage/coverage-summary.json` is generated (consumed by the report action). `coverage/` is gitignored.

Part of the marimo-team engineering-excellence initiative to make existing-but-unenforced quality gates actually run in CI.